### PR TITLE
Update live API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ I am very open to discussing the design of the API and what can be made better. 
 
 ## TODO List
 
-- Change the handlers to have proper context from the request.
+- Make the javascript interop better than the Phoenix design.
 - Missing events, throttle, debounce etc.
 - File uploads
 - Tests... Lots of tests

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ func NewGreeter(ID string, h *live.Handler, s *live.Socket, name string) (Compon
 		ID,
 		h,
 		s,
-		WithMount(func(ctx context.Context, c *Component, r *http.Request, connected bool) error {
+		WithMount(func(ctx context.Context, c *Component, r *http.Request) error {
 			c.State = name
 			return nil
 		}),

--- a/event.go
+++ b/event.go
@@ -1,13 +1,14 @@
 package live
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 )
 
 // EventHandler a function to handle events, returns the data that should
 // be set to the socket after handling.
-type EventHandler func(*Socket, map[string]interface{}) (interface{}, error)
+type EventHandler func(context.Context, *Socket, map[string]interface{}) (interface{}, error)
 
 const (
 	// EventError indicates an error has occured.

--- a/example_test.go
+++ b/example_test.go
@@ -9,24 +9,49 @@ import (
 	"net/http"
 )
 
-// Example_temperature shows a simple temperature control using the
-// "live-click" event.
-func Example_temperature() {
-	// Model of our thermostat.
-	type ThermoModel struct {
-		C float32
-	}
+// Model of our thermostat.
+type ThermoModel struct {
+	C float32
+}
 
-	// Helper function to get the model from the socket data.
-	NewThermoModel := func(s *Socket) *ThermoModel {
-		m, ok := s.Assigns().(*ThermoModel)
-		if !ok {
-			m = &ThermoModel{
-				C: 19.5,
-			}
+// Helper function to get the model from the socket data.
+func NewThermoModel(s *Socket) *ThermoModel {
+	m, ok := s.Assigns().(*ThermoModel)
+	// If we haven't already initialised set up.
+	if !ok {
+		m = &ThermoModel{
+			C: 19.5,
 		}
-		return m
 	}
+	return m
+}
+
+// thermoMount initialises the thermostat state. Data returned in the mount function will
+// automatically be assigned to the socket.
+func thermoMount(ctx context.Context, r *http.Request, s *Socket) (interface{}, error) {
+	return NewThermoModel(s), nil
+}
+
+// tempUp on the temp up event, increase the thermostat temperature by .1 C. An EventHandler function
+// is called with the original request context of the socket, the socket itself containing the current
+// state and and params that came from the event. Params contain query string parameters and any
+// `live-value-` bindings.
+func tempUp(ctx context.Context, s *Socket, params map[string]interface{}) (interface{}, error) {
+	model := NewThermoModel(s)
+	model.C += 0.1
+	return model, nil
+}
+
+// tempDown on the temp down event, decrease the thermostat temperature by .1 C.
+func tempDown(ctx context.Context, s *Socket, params map[string]interface{}) (interface{}, error) {
+	model := NewThermoModel(s)
+	model.C -= 0.1
+	return model, nil
+}
+
+// Example shows a simple temperature control using the
+// "live-click" event.
+func Example() {
 
 	// Setup the handler.
 	h, err := NewHandler(NewCookieStore("session-name", []byte("weak-secret")))
@@ -34,8 +59,15 @@ func Example_temperature() {
 		log.Fatal("could not create handler")
 	}
 
-	// Provide a render function.
-	h.Render = func(ctc context.Context, data interface{}) (io.Reader, error) {
+	// Mount function is called on initial HTTP load and then initial web
+	// socket connection. This should be used to create the initial state,
+	// the socket Connected func will be true if the mount call is on a web
+	// socket connection.
+	h.Mount = thermoMount
+
+	// Provide a render function. Here we are doing it manually, but there is a
+	// provided WithTemplateRenderer which can be used to work with `html/template`
+	h.Render = func(ctx context.Context, data interface{}) (io.Reader, error) {
 		tmpl, err := template.New("thermo").Parse(`
             <div>{{.C}}</div>
             <button live-click="temp-up">+</button>
@@ -53,34 +85,19 @@ func Example_temperature() {
 		return &buf, nil
 	}
 
-	// Mount function is called on initial HTTP load and then initial web
-	// socket connection. This should be used to create the initial state,
-	// the socket Connectedi func will be true if the mount call is on a web
-	// socket connection.
-	h.Mount = func(ctx context.Context, r *http.Request, s *Socket) (interface{}, error) {
-		return NewThermoModel(s), nil
-	}
-
 	// This handles the `live-click="temp-up"` button. First we load the model from
 	// the socket, increment the temperature, and then return the new state of the
 	// model. Live will now calculate the diff between the last time it rendered and now,
 	// produce a set of diffs and push them to the browser to update.
-	h.HandleEvent("temp-up", func(ctx context.Context, s *Socket, _ map[string]interface{}) (interface{}, error) {
-		model := NewThermoModel(s)
-		model.C += 0.1
-		return model, nil
-	})
+	h.HandleEvent("temp-up", tempUp)
 
 	// This handles the `live-click="temp-down"` button.
-	h.HandleEvent("temp-down", func(ctx context.Context, s *Socket, _ map[string]interface{}) (interface{}, error) {
-		model := NewThermoModel(s)
-		model.C -= 0.1
-		return model, nil
-	})
+	h.HandleEvent("temp-down", tempDown)
 
 	http.Handle("/thermostat", h)
 
 	// This serves the JS needed to make live work.
 	http.Handle("/live.js", Javascript{})
+
 	http.ListenAndServe(":8080", nil)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -55,9 +55,9 @@ func Example_temperature() {
 
 	// Mount function is called on initial HTTP load and then initial web
 	// socket connection. This should be used to create the initial state,
-	// the connected variable will be true if the mount call is on a web
+	// the socket Connectedi func will be true if the mount call is on a web
 	// socket connection.
-	h.Mount = func(ctx context.Context, h *Handler, r *http.Request, s *Socket, connected bool) (interface{}, error) {
+	h.Mount = func(ctx context.Context, r *http.Request, s *Socket) (interface{}, error) {
 		return NewThermoModel(s), nil
 	}
 

--- a/example_test.go
+++ b/example_test.go
@@ -65,14 +65,14 @@ func Example_temperature() {
 	// the socket, increment the temperature, and then return the new state of the
 	// model. Live will now calculate the diff between the last time it rendered and now,
 	// produce a set of diffs and push them to the browser to update.
-	h.HandleEvent("temp-up", func(s *Socket, _ map[string]interface{}) (interface{}, error) {
+	h.HandleEvent("temp-up", func(ctx context.Context, s *Socket, _ map[string]interface{}) (interface{}, error) {
 		model := NewThermoModel(s)
 		model.C += 0.1
 		return model, nil
 	})
 
 	// This handles the `live-click="temp-down"` button.
-	h.HandleEvent("temp-down", func(s *Socket, _ map[string]interface{}) (interface{}, error) {
+	h.HandleEvent("temp-down", func(ctx context.Context, s *Socket, _ map[string]interface{}) (interface{}, error) {
 		model := NewThermoModel(s)
 		model.C -= 0.1
 		return model, nil

--- a/page/component.go
+++ b/page/component.go
@@ -14,7 +14,7 @@ import (
 type RegisterHandler func(c *Component) error
 
 // MountHandler the components mount function called on first GET request and again when the socket connects.
-type MountHandler func(ctx context.Context, c *Component, r *http.Request, connected bool) error
+type MountHandler func(ctx context.Context, c *Component, r *http.Request) error
 
 // RenderHandler ths component.
 type RenderHandler func(w io.Writer, c *Component) error
@@ -80,7 +80,7 @@ func Init(ctx context.Context, construct func() (Component, error)) (Component, 
 	if err := comp.Register(&comp); err != nil {
 		return Component{}, fmt.Errorf("could not install component on register: %w", err)
 	}
-	if err := comp.Mount(ctx, &comp, nil, true); err != nil {
+	if err := comp.Mount(ctx, &comp, nil); err != nil {
 		return Component{}, fmt.Errorf("could not install component on mount: %w", err)
 	}
 	return comp, nil
@@ -90,7 +90,7 @@ func Init(ctx context.Context, construct func() (Component, error)) (Component, 
 // components sharing the same ID.
 func (c *Component) Self(ctx context.Context, s *live.Socket, event live.Event) {
 	event.T = c.Event(event.T)
-	c.Handler.Self(ctx, s, event)
+	s.Self(ctx, event)
 }
 
 // HandleSelf handles scoped incoming events send by a components Self function.
@@ -141,7 +141,7 @@ func defaultRegister(c *Component) error {
 }
 
 // defaultMount is the default mount handler which does nothing.
-func defaultMount(ctx context.Context, c *Component, r *http.Request, connected bool) error {
+func defaultMount(ctx context.Context, c *Component, r *http.Request) error {
 	return nil
 }
 

--- a/page/configuration.go
+++ b/page/configuration.go
@@ -40,17 +40,17 @@ func WithRender(fn RenderHandler) ComponentConfig {
 // WithComponentMount set the live.Handler to mount the root component.
 func WithComponentMount(construct ComponentConstructor) live.HandlerConfig {
 	return func(h *live.Handler) error {
-		h.Mount = func(ctx context.Context, h *live.Handler, r *http.Request, s *live.Socket, connected bool) (interface{}, error) {
+		h.Mount = func(ctx context.Context, r *http.Request, s *live.Socket) (interface{}, error) {
 			root, err := construct(ctx, h, r, s)
 			if err != nil {
 				return nil, fmt.Errorf("failed to construct root component: %w", err)
 			}
-			if connected {
+			if s.Connected() {
 				if err := root.Register(&root); err != nil {
 					return nil, err
 				}
 			}
-			if err := root.Mount(ctx, &root, r, connected); err != nil {
+			if err := root.Mount(ctx, &root, r); err != nil {
 				return nil, err
 			}
 			return root, nil

--- a/page/example_test.go
+++ b/page/example_test.go
@@ -15,7 +15,7 @@ func NewGreeter(ID string, h *live.Handler, s *live.Socket, name string) (Compon
 		ID,
 		h,
 		s,
-		WithMount(func(ctx context.Context, c *Component, r *http.Request, connected bool) error {
+		WithMount(func(ctx context.Context, c *Component, r *http.Request) error {
 			c.State = name
 			return nil
 		}),

--- a/socket.go
+++ b/socket.go
@@ -26,16 +26,13 @@ type Socket struct {
 
 	data   interface{}
 	dataMu sync.Mutex
-
-	ctx context.Context
 }
 
 // NewSocket creates a new socket.
-func NewSocket(ctx context.Context, s Session) *Socket {
+func NewSocket(s Session) *Socket {
 	return &Socket{
 		Session: s,
 		msgs:    make(chan Event, maxMessageBufferSize),
-		ctx:     ctx,
 	}
 }
 
@@ -78,11 +75,6 @@ func (s *Socket) Redirect(u *url.URL) {
 	s.Send(e)
 }
 
-// Context get the sockets context.
-func (s *Socket) Context() context.Context {
-	return s.ctx
-}
-
 // mount passes this socket to the handlers mount func. This returns data
 // which we then set to the socket to store.
 func (s *Socket) mount(ctx context.Context, h *Handler, r *http.Request, connected bool) error {
@@ -98,7 +90,7 @@ func (s *Socket) mount(ctx context.Context, h *Handler, r *http.Request, connect
 // which we then set to the socket to store.
 func (s *Socket) params(ctx context.Context, h *Handler, r *http.Request, connected bool) error {
 	for _, ph := range h.paramsHandlers {
-		data, err := ph(s, ParamsFromRequest(r))
+		data, err := ph(ctx, s, ParamsFromRequest(r))
 		if err != nil {
 			return fmt.Errorf("params error: %w", err)
 		}


### PR DESCRIPTION
After some initial use in a more production like environment, we have identified some improvements to the API which we want to make.

- The http request context of the Socket is now available in the event handlers. This is useful for when you have added a user token to the request context, or any other metadata you are passing around from middleware
- The connected attribute in the mount function has been moved to the Socket. `Socket.Connected() bool`
- The `Self` func on the Handler has been removed, `Socket.Self` should be used instead.
- The Socket now has `Socket.Self` and `Socket.Broadcast` these should be favoured for communicating. `Handler.Broadcast` remains, as it could be useful for communicating from another process.