### PR TITLE
feat: Sessions are now extendable with additional info.

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -12,7 +12,7 @@ func NewTestStore(ID string) *TestStore {
 	t := &TestStore{
 		s: NewSession(),
 	}
-	t.s.ID = ID
+	t.s[sessionID] = ID
 	return t
 }
 


### PR DESCRIPTION
Refs:
 - https://github.com/jfyne/live/discussions/31

This PR has a breaking change:

The `Session` is no longer a struct with an ID string on it. It is now a `map[string]interface{}` which should allow people to store arbitrary data in it.

To replace calls to `Session.ID` I have added a helper function `SessionID(s Session) string` which will return the session ID.