### PR TITLE
fix: New Safari does not handle compressed websockets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ export interface Hook {
 }
 
 /**
- * The DOM management interace. This allows external JS libraries to
+ * The DOM management interface. This allows external JS libraries to
  * interop with Live.
  */
 export interface DOM {

--- a/engine.go
+++ b/engine.go
@@ -83,8 +83,9 @@ type BaseEngine struct {
 }
 
 // NewBaseEngine creates a new base engine.
-func NewBaseEngine(h Handler, configs ...EngineConfig) *BaseEngine {
-	e := &BaseEngine{
+func NewBaseEngine(h Handler) *BaseEngine {
+	const maxUploadSize = 100 * 1024 * 1024
+	return &BaseEngine{
 		broadcastLimiter: rate.NewLimiter(rate.Every(time.Millisecond*100), 8),
 		broadcastHandler: func(ctx context.Context, h Engine, msg Event) {
 			h.self(ctx, nil, msg)
@@ -94,12 +95,6 @@ func NewBaseEngine(h Handler, configs ...EngineConfig) *BaseEngine {
 		MaxUploadSize:        100 * 1024 * 1024,
 		handler:              h,
 	}
-	for _, conf := range configs {
-		if err := conf(e); err != nil {
-			log.Println("warning:", fmt.Errorf("could not apply config to engine: %w", err))
-		}
-	}
-	return e
 }
 
 func (e *BaseEngine) Handler(hand Handler) {


### PR DESCRIPTION
Refs:
 - https://github.com/tilt-dev/tilt/issues/4746
 - https://github.com/gorilla/websocket/issues/731
 - https://github.com/nhooyr/websocket/issues/218