### PR TITLE
fix(uploads): support passing socket id through form

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Clicking on this tag will result in the browser URL being updated, and then an e
 trigger the handler's `HandleParams` callback. With the query string being available in the params map of the handler.
 
 ```go
-h.HandleParams(func(s *live.Socket, p live.Params) (interface{}, error) {
+h.HandleParams(func(s *live.Socket, p live.Params) (any, error) {
     ...
     page := p.Int("page")
     ...

--- a/event.go
+++ b/event.go
@@ -31,7 +31,7 @@ type Event struct {
 	T        string          `json:"t"`
 	ID       int             `json:"i,omitempty"`
 	Data     json.RawMessage `json:"d,omitempty"`
-	SelfData interface{}     `json:"s,omitempty"`
+	SelfData any             `json:"s,omitempty"`
 }
 
 // Params extract params from inbound message.

--- a/examples/uploads/view.html
+++ b/examples/uploads/view.html
@@ -21,6 +21,7 @@
 <!-- Forms require an ID so that we can track changes in them -->
 <form id="test-form" live-change="validate" live-submit="save">
     <fieldset>
+        <input type="hidden" name="_psid" value="{{ $.Socket.ID }}">
         <label>
             <div>
             {{ if index .Uploads "photos" }}
@@ -40,8 +41,8 @@
         </label>
     </fieldset>
     <fieldset>
-        <input type="submit" 
-        {{ if .Uploads.HasErrors }}
+        <input type="submit"
+        {{ if or .Uploads.HasErrors (not (index .Uploads "photos" ))}}
         disabled="true"
         {{ end }}
         >
@@ -52,5 +53,6 @@
     {{ range $u := .Assigns.Uploads }}
     <li><img src="/static/{{$u}}" alt="{{$u}}"/></li>
     {{ end }}
+</ul>
 
 {{ end }}

--- a/handler.go
+++ b/handler.go
@@ -45,7 +45,7 @@ type Handler struct {
 	// is called on initial GET request and later when the websocket connects.
 	// Data to render the handler should be fetched here and returned.
 	MountHandler MountHandler
-	// UnmountHandler used to track webcocket disconnections.
+	// UnmountHandler used to track websocket disconnections.
 	UnmountHandler UnmountHandler
 	// Render is called to generate the HTML of a Socket. It is defined
 	// by default and will render any template provided.
@@ -105,7 +105,7 @@ func (h *Handler) HandleSelf(t string, handler SelfHandler) {
 }
 
 // HandleParams handles a URL query parameter change. This is useful for handling
-// things like pagincation, or some filtering.
+// things like pagination, or some filtering.
 func (h *Handler) HandleParams(handler EventHandler) {
 	h.paramsHandlers = append(h.paramsHandlers, handler)
 }

--- a/params.go
+++ b/params.go
@@ -30,7 +30,7 @@ func (p Params) Checkbox(key string) bool {
 	return false
 }
 
-func mapString(p map[string]interface{}, key string) string {
+func mapString(p map[string]any, key string) string {
 	v, ok := p[key]
 	if !ok {
 		return ""
@@ -47,7 +47,7 @@ func (p Params) Int(key string) int {
 	return mapInt(p, key)
 }
 
-func mapInt(p map[string]interface{}, key string) int {
+func mapInt(p map[string]any, key string) int {
 	v, ok := p[key]
 	if !ok {
 		return 0
@@ -74,7 +74,7 @@ func (p Params) Float32(key string) float32 {
 	return mapFloat32(p, key)
 }
 
-func mapFloat32(p map[string]interface{}, key string) float32 {
+func mapFloat32(p map[string]any, key string) float32 {
 	v, ok := p[key]
 	if !ok {
 		return 0.0

--- a/render.go
+++ b/render.go
@@ -14,7 +14,7 @@ import (
 type RenderContext struct {
 	Socket  *Socket
 	Uploads UploadContext
-	Assigns interface{}
+	Assigns any
 }
 
 // RenderSocket takes the engine and current socket and renders it to html.

--- a/upload.go
+++ b/upload.go
@@ -89,7 +89,7 @@ type UploadProgress struct {
 
 // Write interface to track progress of an upload.
 func (u *UploadProgress) Write(p []byte) (n int, err error) {
-	n, err = len(p), nil
+	n = len(p)
 	u.Upload.bytesRead += int64(n)
 	u.Upload.Progress = float32(u.Upload.bytesRead) / float32(u.Upload.Size)
 	render, err := RenderSocket(context.Background(), u.Engine, u.Socket)
@@ -106,14 +106,14 @@ func (u *UploadProgress) Write(p []byte) (n int, err error) {
 func ValidateUploads(s *Socket, p Params) {
 	s.ClearUploads()
 
-	input, ok := p[upKey].(map[string]interface{})
+	input, ok := p[upKey].(map[string]any)
 	if !ok {
 		slog.Warn("validate uploads", "err", ErrUploadNotFound)
 		return
 	}
 
 	for _, c := range s.UploadConfigs() {
-		uploads, ok := input[c.Name].([]interface{})
+		uploads, ok := input[c.Name].([]any)
 		if !ok {
 			s.AssignUpload(c.Name, &Upload{Errors: []error{ErrUploadNotFound}})
 			continue
@@ -122,7 +122,7 @@ func ValidateUploads(s *Socket, p Params) {
 			s.AssignUpload(c.Name, &Upload{Errors: []error{&UploadError{err: ErrUploadTooManyFiles}}})
 		}
 		for _, u := range uploads {
-			f, ok := u.(map[string]interface{})
+			f, ok := u.(map[string]any)
 			if !ok {
 				s.AssignUpload(c.Name, &Upload{Errors: []error{&UploadError{err: ErrUploadNotFound}}})
 				continue


### PR DESCRIPTION
This PR fixes the file upload example, the biggest change is that you can (have to?) pass the socket id `_psid` through a form value rather than relying on the cookie which expires quickly.  

I'm new to this code base so I've left explanation comments on each of my changes below. 