### PR TITLE
fix: initialize closeSlow in NewSocket to avoid nil panic

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -89,6 +89,7 @@ func NewSocket(ctx context.Context, e *Engine, withID SocketID) *Socket {
 		id:            withID,
 		engine:        e,
 		connected:     withID != "",
+		closeSlow:     func() {},
 		uploadConfigs: []*UploadConfig{},
 		msgs:          make(chan Event, maxMessageBufferSize),
 		selfChan:      make(chan socketSelfOp),


### PR DESCRIPTION
This fixes a nil pointer panic that could happen if `Send` is called many times before the websocket connection is established (channel gets full, then `Send()` calls `go s.closeSlow()`). 