### PR TITLE
fix(patch): pass new element to updated() hook instead of stale reference

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -46,6 +46,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.8.tgz",
             "integrity": "sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.15.8",
                 "@babel/generator": "^7.15.8",
@@ -1342,6 +1343,7 @@
             "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.2.tgz",
             "integrity": "sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "jest-diff": "^27.0.0",
                 "pretty-format": "^27.0.0"
@@ -2602,6 +2604,7 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-27.3.1.tgz",
             "integrity": "sha512-U2AX0AgQGd5EzMsiZpYt8HyZ+nSVIh5ujQ9CPp9EQZJMjXIiSZpJNweZl0swatKRoqHWgGKM3zaSwm4Zaz87ng==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^27.3.1",
                 "import-local": "^3.0.2",
@@ -4243,6 +4246,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
             "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -4522,6 +4526,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.8.tgz",
             "integrity": "sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@babel/code-frame": "^7.15.8",
                 "@babel/generator": "^7.15.8",
@@ -5376,6 +5381,7 @@
             "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.2.tgz",
             "integrity": "sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "jest-diff": "^27.0.0",
                 "pretty-format": "^27.0.0"
@@ -6346,6 +6352,7 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-27.3.1.tgz",
             "integrity": "sha512-U2AX0AgQGd5EzMsiZpYt8HyZ+nSVIh5ujQ9CPp9EQZJMjXIiSZpJNweZl0swatKRoqHWgGKM3zaSwm4Zaz87ng==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@jest/core": "^27.3.1",
                 "import-local": "^3.0.2",
@@ -7585,7 +7592,8 @@
             "version": "4.4.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
             "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "universalify": {
             "version": "0.2.0",

--- a/web/src/patch.ts
+++ b/web/src/patch.ts
@@ -33,14 +33,12 @@ export class Patch {
             case 1: // REPLACE
                 if (e.HTML === "") {
                     EventDispatch.beforeDestroy(target);
-                } else {
-                    EventDispatch.beforeUpdate(target, newElement as Element);
-                }
-                target.outerHTML = e.HTML;
-                if (e.HTML === "") {
+                    target.remove();
                     EventDispatch.destroyed(target);
                 } else {
-                    EventDispatch.updated(target);
+                    EventDispatch.beforeUpdate(target, newElement as Element);
+                    target.replaceWith(newElement);
+                    EventDispatch.updated(newElement as Element);
                 }
                 break;
             case 2: // APPEND


### PR DESCRIPTION
In the TypeScript client's `Patch.applyPatch`, the REPLACE action uses `target.outerHTML = e.HTML` to swap an element. After this assignment, `target` still references the old element that was removed from the DOM. The subsequent call to `EventDispatch.updated(target)` passes this detached "ghost" element to user hooks.

This PR changes the logic to use `replaceWith` and only parses the HTML once, which should also be a net performance improvement (especially for large diffs).