### PR TITLE
fix: copy websocket.AcceptOptions to avoid CompressionMode leak

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -489,14 +489,17 @@ func (e *Engine) get(ctx context.Context, w http.ResponseWriter, r *http.Request
 
 // serveWS serve a websocket request to the handler.
 func (e *Engine) serveWS(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	opts := e.acceptOptions
 	if strings.Contains(r.UserAgent(), "Safari") {
-		if e.acceptOptions == nil {
-			e.acceptOptions = &websocket.AcceptOptions{}
+		var local websocket.AcceptOptions
+		if opts != nil {
+			local = *opts
 		}
-		e.acceptOptions.CompressionMode = websocket.CompressionDisabled
+		local.CompressionMode = websocket.CompressionDisabled
+		opts = &local
 	}
 
-	c, err := websocket.Accept(w, r, e.acceptOptions)
+	c, err := websocket.Accept(w, r, opts)
 	if err != nil {
 		e.Handler.ErrorHandler(ctx, err)
 		return


### PR DESCRIPTION
In `serveWS`, when a Safari user-agent is detected, the code mutates `e.acceptOptions.CompressionMode` directly to disable compression. Since `e.acceptOptions` is shared across all requests, this mutation leaks to subsequent non-Safari connections (they also get compression disabled). There is also a data race: concurrent WebSocket upgrades read and write the same struct field without synchronization.

I replaced the shared mutation with a per-request local copy. Non-Safari requests pass `e.acceptOptions` as-is (read-only). Safari requests shallow-copy the struct into a local variable and set `CompressionDisabled` on the copy. The shared `e.acceptOptions` is never modified after initialization.