### PR TITLE
fix(examples/alpine): restore build pipeline and fix client-server protocol mismatch

### DIFF
--- a/examples/alpine/README.md
+++ b/examples/alpine/README.md
@@ -1,4 +1,14 @@
 # Alpine example
 
 Demonstrates importing the `@jfyne/live` package, integrating with alpine.js and compiling it with `esbuild`. This
-produces a `main.js` which we then serve using go.
+bundles `index.js` into `main.js` which is then embedded and served by the Go binary.
+
+## Setup
+
+```bash
+cd examples/alpine
+npm install
+npm run prepare
+cd ..
+go run ./alpine
+```

--- a/examples/alpine/index.js
+++ b/examples/alpine/index.js
@@ -1,0 +1,23 @@
+import { Live } from "@jfyne/live";
+import "alpinejs";
+
+document.addEventListener("DOMContentLoaded", (_) => {
+    const hooks = {
+        "example-hook": {
+            mounted: () => {
+                console.log(
+                    "This is an example of passing hooks into live anywhere you want."
+                );
+            },
+        },
+    };
+    const dom = {
+        onBeforeElUpdated: (from, to) => {
+            if (from.__x) {
+                window.Alpine.clone(from.__x, to);
+            }
+        },
+    };
+    const l = new Live(hooks, dom);
+    l.init();
+});

--- a/examples/alpine/package.json
+++ b/examples/alpine/package.json
@@ -9,7 +9,7 @@
     "author": "",
     "license": "MIT",
     "dependencies": {
-        "@jfyne/live": "^0.9.2",
+        "@jfyne/live": "^0.16.3",
         "alpinejs": "^2.8.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## What's changed

Restores the deleted `index.js` esbuild entry point, updates the `@jfyne/live` npm dependency from `^0.9.2` to `^0.16.3` to match the server protocol, and adds build instructions to the Alpine example README.

Refs:
 - #113

## Suggested Review Order

| # | File | What it does |
|---|------|-------------|
| 1 | [`index.js`](https://github.com/jfyne/live/pull/116/files#diff-d69675fd641f2ec20d036269868cdc5eca7318880d3c03374cbcd965baacced8) | Restored esbuild entry point that bundles `@jfyne/live` and `alpinejs` into a single browser-ready script |
| 2 | [`package.json`](https://github.com/jfyne/live/pull/116/files#diff-4971d31067f060972033abdc166b90006490e3eb4ff55baf5622e8dbdca04e74) | Updates `@jfyne/live` from `^0.9.2` to `^0.16.3` to fix client-server protocol mismatch |
| 3 | [`README.md`](https://github.com/jfyne/live/pull/116/files#diff-9de82b200fdb41bd6a401b9bedcf0ac9346625b09f2581d169c52772ea17f40f) | Adds setup instructions documenting the npm install → build → go run workflow |
