### PR TITLE
fix: handle <-ctx.Done() in Socket.Self() method

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -172,6 +172,8 @@ func (s *Socket) Self(ctx context.Context, event string, data any) error {
 		return nil
 	case err := <-op.err:
 		return err
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 


### PR DESCRIPTION
Hello :) I found this library pretty and promising. Just noticed one little thing as lack of context control in `Socket.Self()`.

It might be useful in such scenarios when background task is launched and callback is required to be called in case if live.Socket is still active.